### PR TITLE
Add local setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ This repo contains two files:
 - **elixir-ecosystem-survey-2020-processed-data.dump**: this file contains a PostgreSQL dump with the processed data. You can load that to a PostgreSQL instance and start exploring it
 - **elixir-ecosystem-survey-2020-raw-data.csv**: this file contains the original CSV export from the survey (you can also find the [original file here](https://drive.google.com/file/d/1iddghuuob9_e9CFm05VnHjlELiwgnQqz/view))
 
+# Local setup
+
+1. `git clone git@github.com:hugobarauna/elixir-ecosystem-2020-reponses-data.git`
+1. `cd elixir-ecosystem-2020-reponses-data`
+1. `createdb -T template0 elixir_survey_results`
+1. `psql elixir_survey_results < elixir-ecosystem-survey-2020-processed-data.dump`
+
 # Query examples
 
 Here are two examples of queries you can run:


### PR DESCRIPTION
So people don't have to hunt through the postgres docs. I did see an error or two when running this, but it seemed to import fine.
```
➜  elixir-ecosystem-2020-reponses-data git:(main) createdb -T template0 elixir_s
urvey_results
➜  elixir-ecosystem-2020-reponses-data git:(main) ls
README.md
elixir-ecosystem-survey-2020-processed-data.dump
elixir-ecosystem-survey-2020-raw-data.csv
➜  elixir-ecosystem-2020-reponses-data git:(main) psql elixir_survey_results < e
lixir-ecosystem-survey-2020-processed-data.dump
SET
SET
SET
SET
SET
 set_config
------------

(1 row)

SET
SET
SET
SET
CREATE EXTENSION
COMMENT
SET
ERROR:  unrecognized configuration parameter "default_table_access_method"
CREATE TABLE
ERROR:  role "hugobarauna" does not exist
COPY 3108
```

Unrelated issue: all the questions that are longer than the character limit for postgres columns seem to have `NULL` for all responses (probably didn't import right). For example, `"Have you made contributions to anyone else's OSS Elixir librari"`, and several others.